### PR TITLE
fixed wanky vars in index.ejs

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,15 +9,13 @@
 
   <br>
 
-<!--<h3> <%= player_name %> </h3>
-<h3> <%= position %></h3>
-<h3> <%= number %></h3>-->
+
 
 
   <ul class = "players">
     <% for(var i=0; i< players.length; i++) { %>
       <form method="POST" action="/deletePlayers/<%= players[i]._id %>" style="display: inline-block">
-        <%= players[i].player_name %> ( <%= players[i].position %>) (<%= players[i].number %>)
+        <%= players[i].name %> ( <%= players[i].positon %>) (<%= players[i].number %>)
         <input type="submit" value="delete">
       </form>
       <br/>


### PR DESCRIPTION
you cannot just comment out ejs code. 

the ejs stuff `<%= %>` cuts through 🔪 html comments like a ninja. so that `<h3>` stuff needed to be deleted. 

Also fixed a **very** troublesome variable name. In your database, your filed is misspelled: `positon` (not `position`). This made life more confusing than it should be. 

Also, make sure you have your heroku config var set up. 